### PR TITLE
Fix spacing in prompt and sync with gitster.zsh-theme

### DIFF
--- a/gitster.zsh-theme
+++ b/gitster.zsh-theme
@@ -21,5 +21,5 @@ if (( ${+functions[git-info]} )); then
   autoload -Uz add-zsh-hook && add-zsh-hook precmd git-info
 fi
 
-PS1='%(?:%F{green}:%F{red})%{%G➜%}  %F{white}$(prompt-pwd)${(e)git_info[prompt]}%f '
+PS1='%B%(?:%F{green}:%F{red})%{%G➜%} %F{white}$(prompt-pwd)${(e)git_info[prompt]}%f%b '
 unset RPS1

--- a/gitster.zsh-theme
+++ b/gitster.zsh-theme
@@ -13,13 +13,13 @@ typeset -gA git_info
 if (( ${+functions[git-info]} )); then
   zstyle ':zim:git-info:branch' format '%b'
   zstyle ':zim:git-info:commit' format '%c'
-  zstyle ':zim:git-info:clean' format '%F{green}✓'
-  zstyle ':zim:git-info:dirty' format '%F{yellow}✗'
+  zstyle ':zim:git-info:clean' format '%F{green}%{%G✓%}'
+  zstyle ':zim:git-info:dirty' format '%F{yellow}%{%G✗%}'
   zstyle ':zim:git-info:keys' format \
       'prompt' ' %F{cyan}%b%c %C%D'
 
   autoload -Uz add-zsh-hook && add-zsh-hook precmd git-info
 fi
 
-PS1='%(?:%F{green}:%F{red})➜ %F{white}$(prompt-pwd)${(e)git_info[prompt]}%f '
+PS1='%(?:%F{green}:%F{red})%{%G➜%}  %F{white}$(prompt-pwd)${(e)git_info[prompt]}%f '
 unset RPS1


### PR DESCRIPTION
zim vim oh-my-zsh:

![image](https://github.com/zimfw/gitster/assets/817046/771ccea7-354e-4e85-9398-92b6531f9072)

- Added a space between the `➜` and the folder name.
- Fix a spacing issue on tab complete using this solution: https://stackoverflow.com/a/58196512
- Not sure if we should make the prompt bold to make them even simliar?